### PR TITLE
Remove cluster_name property for apiserver

### DIFF
--- a/libraries/kube_apiserver.rb
+++ b/libraries/kube_apiserver.rb
@@ -84,7 +84,6 @@ module KubernetesCookbook
     property :client_ca_file
     property :cloud_config
     property :cloud_provider
-    property :cluster_name, default: 'kubernetes'
     property :cors_allowed_origins, default: []
     property :etcd_config
     property :etcd_prefix, default: '/registry'


### PR DESCRIPTION
Just a small fix for the `--cluster-name` argument which is not allowed by the `kube-apiserver`.

Output from when I accidentally set this value:
```
Sep 02 16:22:26 kube-apiserver-0.beta.aws kube-apiserver[27412]: unknown flag: --cluster-name
Sep 02 16:22:26 kube-apiserver-0.beta.aws systemd[1]: kube-apiserver.service: main process exited, code=exited, status=2/INVALIDARGUMENT
```

See: http://kubernetes.io/docs/admin/kube-apiserver/

Thanks for the cookbook, and please let me know if there's something I should change.