### PR TITLE
Add missing configuration options for components

### DIFF
--- a/libraries/kube_apiserver.rb
+++ b/libraries/kube_apiserver.rb
@@ -76,8 +76,15 @@ module KubernetesCookbook
     property :admission_control_config_file
     property :advertise_address
     property :allow_privileged, default: false
+    property :apiserver_count, default: 1
+    property :authentication_token_webhook_cache_ttl, default: '2m0s'
+    property :authentication_token_webhook_config_file
     property :authorization_mode, default: 'AlwaysAllow'
     property :authorization_policy_file
+    property :authorization_rbac_super_user
+    property :authorization_webhook_cache_authorized_ttl, default: '5m0s'
+    property :authorization_webhook_cache_unauthorized_ttl, default: '30s'
+    property :authorization_webhook_config_file
     property :basic_auth_file
     property :bind_address, default: '0.0.0.0'
     property :cert_dir, default: '/var/run/kubernetes'
@@ -85,10 +92,18 @@ module KubernetesCookbook
     property :cloud_config
     property :cloud_provider
     property :cors_allowed_origins, default: []
+    property :delete_collection_workers, default: 1
+    property :deserialization_cache_size, default: 50000
+    property :enable_garbage_collector, default: false
+    property :enable_swagger_ui, default: false
+    property :etcd_cafile
+    property :etcd_certfile
     property :etcd_config
+    property :etcd_keyfile
     property :etcd_prefix, default: '/registry'
     property :etcd_servers, default: []
     property :etcd_servers_overrides, default: []
+    property :etcd_quorum_read, default: false
     property :event_ttl, default: '1h0m0s'
     property :experimental_keystone_url
     property :external_hostname
@@ -101,6 +116,7 @@ module KubernetesCookbook
     property :kubelet_https, default: true
     property :kubelet_port, default: 10_250
     property :kubelet_timeout, default: '5s'
+    property :kubernetes_service_node_port, default: 0
     property :log_flush_frequency, default: '5s'
     property :long_running_request_regexp,
              default: '(/|^)((watch|proxy)(/|$)|'\
@@ -111,9 +127,11 @@ module KubernetesCookbook
     property :min_request_timeout, default: 1800
     property :oidc_ca_file
     property :oidc_client_id
+    property :oidc_groups_claim
     property :oidc_issuer_url
     property :oidc_username_claim, default: 'sub'
     property :profiling, default: true
+    property :repair_malformed_updates, default: true
     property :runtime_config
     property :secure_port, default: 6443
     property :service_account_key_file
@@ -122,11 +140,14 @@ module KubernetesCookbook
     property :service_node_port_range
     property :ssh_keyfile
     property :ssh_user
+    property :storage_backend
+    property :storage_media_type, default: 'application/json'
     property :storage_versions, default: %w(extensions/v1beta1 v1)
     property :tls_cert_file
     property :tls_private_key_file
     property :token_auth_file
     property :watch_cache, default: true
+    property :watch_cache_sizes
 
     property :v, default: 0 # TODO: move to common class
   end

--- a/libraries/kube_controller_manager.rb
+++ b/libraries/kube_controller_manager.rb
@@ -65,18 +65,37 @@ module KubernetesCookbook
     property :cloud_provider
     property :cluster_cidr
     property :cluster_name, default: 'kubernetes'
+    property :concurrent_deployment_syncs, default: 5
     property :concurrent_endpoint_syncs, default: 5
+    property :concurrent_namespace_syncs, default: 2
     property :concurrent_rc_syncs, default: 5
+    property :concurrent_replicaset_syncs, default: 5
+    property :concurrent_resource_quota_syncs, default: 5
+    property :configure_cloud_routes, default: true
+    property :controller_start_interval, default: 0
+    property :daemonset_lookup_cache_size, default: 1024
     property :deleting_pods_burst, default: 10
     property :deleting_pods_qps, default: 0.1
     property :deployment_controller_sync_period, default: '30s'
+    property :enable_dynamic_provisioning, default: true
+    property :enable_garbage_collector, default: false
+    property :enable_hostpath_provisioner, default: false
+    property :flex_volume_plugin_dir, default: '/usr/libexec/kubernetes/kubelet_plugins/volume/exec/'
     property :google_json_key
     property :horizontal_pod_autoscaler_sync_period, default: '30s'
+    property :kube_api_burst, default: 30
+    property :kube_api_content_type, default: 'application/vnd.kubernetes.protobuf'
+    property :kube_api_qps, default: 20
     property :kubeconfig
+    property :leader_elect, default: false
+    property :leader_elect_lease_duration, default: '15s'
+    property :leader_elect_renew_deadline, default: '10s'
+    property :leader_elect_retry_period, default: '2s'
     property :log_flush_frequency, default: '5s'
     property :master
     property :min_resync_period, default: '12h0m0s'
     property :namespace_sync_period, default: '5m0s'
+    property :node_cidr_mask_size, default: 24
     property :node_monitor_grace_period, default: '40s'
     property :node_monitor_period, default: '5s'
     property :node_startup_grace_period, default: '1m0s'
@@ -91,9 +110,12 @@ module KubernetesCookbook
     property :pv_recycler_pod_template_filepath_nfs
     property :pv_recycler_timeout_increment_hostpath, default: 30
     property :pvclaimbinder_sync_period, default: '10s'
+    property :replicaset_lookup_cache_size, default: 4096
+    property :replication_controller_lookup_cache_size, default: 4096
     property :resource_quota_sync_period, default: '10s'
     property :root_ca_file
     property :service_account_private_key_file
+    property :service_cluster_ip_range
     property :service_sync_period, default: '5m0s'
     property :terminated_pod_gc_threshold, default: 12_500
   end

--- a/libraries/kube_proxy.rb
+++ b/libraries/kube_proxy.rb
@@ -53,11 +53,19 @@ module KubernetesCookbook
   class KubeProxy < Chef::Resource
     property :bind_address, default: '0.0.0.0'
     property :cleanup_iptables, default: false
+    property :cluster_cidr
+    property :config_sync_period, default: '15m0s'
+    property :conntrack_max, default: 0
+    property :conntrack_max_per_core, default: 32_768
+    property :conntrack_tcp_timeout_established, default: '24h0m0s'
     property :google_json_key
     property :healthz_bind_address, default: '127.0.0.1'
     property :healthz_port, default: 10_249
     property :hostname_override
     property :iptables_sync_period, default: '30s'
+    property :kube_api_burst, default: 10
+    property :kube_api_content_type, default: 'application/vnd.kubernetes.protobuf'
+    property :kube_api_qps, default: 5
     property :kubeconfig
     property :log_flush_frequency, default: '5s'
     property :masquerade_all, default: false

--- a/libraries/kube_scheduler.rb
+++ b/libraries/kube_scheduler.rb
@@ -61,12 +61,23 @@ module KubernetesCookbook
     property :algorithm_provider, default: 'DefaultProvider'
     property :bind_pods_burst, default: 100
     property :bind_pods_qps, default: 50
+    property :failure_domains, default: 'kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region'
     property :google_json_key
+    property :hard_pod_affinity_symmetric_weight, default: 1
+    property :kube_api_burst, default: 100
+    property :kube_api_content_type, default: 'application/vnd.kubernetes.protobuf'
+    property :kube_api_qps, default: 50
     property :kubeconfig
+    property :leader_elect, default: false
+    property :leader_elect_lease_duration, default: '15s'
+    property :leader_elect_renew_deadline, default: '10s'
+    property :leader_elect_retry_period, default: '2s'
     property :log_flush_frequency, default: '5s'
     property :master
     property :policy_config_file
     property :port, default: 10_251
     property :profiling, default: true
+    property :scheduler_name, default: 'default-scheduler'
   end
+
 end

--- a/libraries/kubelet.rb
+++ b/libraries/kubelet.rb
@@ -92,12 +92,23 @@ module KubernetesCookbook
     property :cpu_cfs_quota, default: false
     property :docker_endpoint
     property :docker_exec_handler, default: 'native'
+    property :enable_controller_attach_detach, default: true
+    property :enable_custom_metrics, default: false
     property :enable_debugging_handlers, default: true
     property :enable_server, default: true
     property :event_burst, default: 0
     property :event_qps, default: 0
+    property :eviction_hard
+    property :eviction_max_pod_grace_period, default: 0
+    property :eviction_pressure_transition_period, default: '5m0s'
+    property :eviction_soft
+    property :eviction_soft_grace_period
+    property :exit_on_lock_contention, default: false
+    property :experimental_flannel_overlay, default: false
+    property :experimental_nvidia_gpus, default: 0
     property :file_check_frequency, default: '20s'
     property :google_json_key
+    property :hairpin_mode, default: 'promiscuous_bridge'
     property :healthz_bind_address, default: '127.0.0.1'
     property :healthz_port, default: 10_248
     property :host_ipc_sources, default: '*'
@@ -107,7 +118,13 @@ module KubernetesCookbook
     property :http_check_frequency, default: '20s'
     property :image_gc_high_threshold, default: 90
     property :image_gc_low_threshold, default: 80
+    property :kube_api_burst, default: 10
+    property :kube_api_content_type, default: 'application/vnd.kubernetes.protobuf'
+    property :kube_api_qps, default: 5
+    property :kube_reserved
     property :kubeconfig, default: '/var/lib/kubelet/kubeconfig'
+    property :kubelet_cgroups
+    property :lock_file
     property :log_flush_frequency, default: '5s'
     property :low_diskspace_threshold_mb, default: 256
     property :manifest_url
@@ -118,31 +135,47 @@ module KubernetesCookbook
     property :maximum_dead_containers, default: 100
     property :maximum_dead_containers_per_container, default: 2
     property :minimum_container_ttl_duration, default: '1m0s'
+    property :minimum_image_ttl_duration, default: '2m0s'
     property :network_plugin
     property :network_plugin_dir,
              default: '/usr/libexec/kubernetes/kubelet_plugins/net/exec/'
+    property :node_ip
+    property :node_labels
     property :node_status_update_frequency, default: '10s'
+    property :non_masquerade_cidr, default: '10.0.0.0/8'
     property :oom_score_adj, default: -999
+    property :outofdisk_transition_frequency, default: '5m0s'
     property :pod_cidr
+    property :pods_per_core, default: 0
     property :pod_infra_container_image,
              default: 'gcr.io/google_containers/pause'
     property :port, default: 10_250
     property :read_only_port, default: 10_255
     property :really_crash_for_testing, default: false
+    property :reconcile_cidr, default: true
     property :register_node, default: true
+    property :register_schedulable, default: true
     property :registry_burst, default: 10
     property :registry_qps, default: 0
     property :resolv_conf, default: '/etc/resolv.conf'
     property :resource_container, default: '/kubelet'
+    property :rkt_api_endpoint, default: 'localhost:15441'
     property :rkt_path
     property :rkt_stage1_image
     property :root_dir, default: '/var/lib/kubelet'
     property :runonce, default: false
+    property :runtime_cgroups
+    property :runtime_request_timeout, default: '2m0s'
+    property :seccomp_profile_root, default: '/var/lib/kubelet/seccomp'
     property :serialize_image_pulls, default: true
     property :streaming_connection_idle_timeout, default: 0
     property :sync_frequency, default: '10s'
+    property :system_cgroups
     property :system_container
+    property :system_reserved
     property :tls_cert_file
     property :tls_private_key_file
+    property :volume_plugin_dir, default: '/usr/libexec/kubernetes/kubelet-plugins/volume/exec/'
+    property :volume_stats_agg_period, default: '1m0s'
   end
 end


### PR DESCRIPTION
Adds some configuration options that were likely added recently. I needed to use `--leader-elect` but decided that it might be better just to add everything listed in the docs ([kube-apiserver docs](http://kubernetes.io/docs/admin/kube-apiserver/) for example).

There's a lot of changes so please let me know what I can do to make this easier to merge. As an aside I can see why you chose not to render default parameters :)

Thanks again for the cookbook!