### PR TITLE
Remove hardcoded commandline options from kube_apiserver

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 3.0.0
+
+* Change kube_apiserver to take hash options
+
 # 2.0.0
 
 * Update resource properties to commandline flags in 1.4.0

--- a/libraries/command_generator.rb
+++ b/libraries/command_generator.rb
@@ -17,6 +17,16 @@ module KubernetesCookbook
       end
     end
 
+    def generate_from_hash
+      actual_flags = @resource.class.properties[:options].map do |option, data|
+        data = data.join ',' if value.is_a? Array
+        "--#{option.to_s.tr('_', '-')}=#{data}"
+      end
+      actual_flags.reduce @binary do |command, flag|
+        command << " #{flag}"
+      end
+    end
+
     private
 
     def non_commandline_property?(property)

--- a/libraries/kube_apiserver.rb
+++ b/libraries/kube_apiserver.rb
@@ -10,6 +10,7 @@ module KubernetesCookbook
       default: '1638e88dec8e33e7099006638507916f' \
                '889087a98790a3e485db03204291ec9a'
     property :run_user, String, default: 'kubernetes'
+    property :options, Hash, default: {}
 
     default_action :create
 
@@ -67,93 +68,5 @@ module KubernetesCookbook
     def file_cache_path
       Chef::Config[:file_cache_path]
     end
-  end
-
-  # Commandline-related properties
-  # Reference: http://kubernetes.io/docs/admin/kube-apiserver/
-  class KubeApiserver < Chef::Resource
-    property :admission_control, default: 'AlwaysAdmit'
-    property :admission_control_config_file
-    property :advertise_address
-    property :allow_privileged
-    property :apiserver_count, default: 1
-    property :audit_log_maxage
-    property :audit_log_maxbackup
-    property :audit_log_maxsize
-    property :audit_log_path
-    property :authentication_token_webhook_cache_ttl, default: '2m0s'
-    property :authentication_token_webhook_config_file
-    property :authorization_mode, default: 'AlwaysAllow'
-    property :authorization_policy_file
-    property :authorization_rbac_super_user
-    property :authorization_webhook_cache_authorized_ttl, default: '5m0s'
-    property :authorization_webhook_cache_unauthorized_ttl, default: '30s'
-    property :authorization_webhook_config_file
-    property :basic_auth_file
-    property :bind_address, default: '0.0.0.0'
-    property :cert_dir, default: '/var/run/kubernetes'
-    property :client_ca_file
-    property :cloud_config
-    property :cloud_provider
-    property :cors_allowed_origins, default: []
-    property :delete_collection_workers, default: 1
-    property :deserialization_cache_size, default: 50_000
-    property :enable_garbage_collector, default: true
-    property :enable_swagger_ui
-    property :etcd_cafile
-    property :etcd_certfile
-    property :etcd_keyfile
-    property :etcd_prefix, default: '/registry'
-    property :etcd_servers, default: []
-    property :etcd_servers_overrides, default: []
-    property :etcd_quorum_read
-    property :event_ttl, default: '1h0m0s'
-    property :experimental_keystone_url
-    property :external_hostname
-    property :feature_gates
-    property :google_json_key
-    property :insecure_bind_address, default: '127.0.0.1'
-    property :insecure_port, default: 8080
-    property :kubelet_certificate_authority
-    property :kubelet_client_certificate
-    property :kubelet_client_key
-    property :kubelet_https, default: true
-    property :kubelet_port, default: 10_250
-    property :kubelet_timeout, default: '5s'
-    property :kubernetes_service_node_port
-    property :log_flush_frequency, default: '5s'
-    property :long_running_request_regexp,
-             default: '(/|^)((watch|proxy)(/|$)|'\
-                      '(logs?|portforward|exec|attach)/?$)'
-    property :master_service_namespace, default: 'default'
-    property :max_connection_bytes_per_sec, default: 0
-    property :max_requests_inflight, default: 400
-    property :min_request_timeout, default: 1800
-    property :oidc_ca_file
-    property :oidc_client_id
-    property :oidc_groups_claim
-    property :oidc_issuer_url
-    property :oidc_username_claim, default: 'sub'
-    property :profiling, default: true
-    property :repair_malformed_updates, default: true
-    property :runtime_config
-    property :secure_port, default: 6443
-    property :service_account_key_file
-    property :service_account_lookup
-    property :service_cluster_ip_range
-    property :service_node_port_range, default: '30000-32767'
-    property :ssh_keyfile
-    property :ssh_user
-    property :storage_backend
-    property :storage_media_type, default: 'application/json'
-    property :storage_versions
-    property :target_ram_mb
-    property :tls_cert_file
-    property :tls_private_key_file
-    property :token_auth_file
-    property :watch_cache, default: true
-    property :watch_cache_sizes, default: []
-
-    property :v, default: 0 # TODO: move to common class
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,4 @@ license 'Apache v2.0'
 source_url 'https://github.com/aespinosa/cookbook-kube'
 issues_url 'https://github.com/aespinosa/cookbook-kube/issues'
 
-version '2.0.0'
+version '3.0.0'

--- a/test/cookbooks/kube_test/recipes/default.rb
+++ b/test/cookbooks/kube_test/recipes/default.rb
@@ -18,10 +18,13 @@ etcd_service 'default' do
   action %w(create start)
 end # Needed by the kube_apiserver[default]
 
+options = {
+  :service_cluster_ip_range => '10.0.0.1/24',
+  :etcd_servers => 'http://127.0.0.1:4001',
+  :insecure_bind_address => '0.0.0.0' # for convenience
+}
 kube_apiserver 'default' do
-  service_cluster_ip_range '10.0.0.1/24'
-  etcd_servers 'http://127.0.0.1:4001'
-  insecure_bind_address '0.0.0.0' # for convenience
+  options options
   action %w(create start)
 end
 


### PR DESCRIPTION
An attempt at addressing the issue discussed in https://github.com/aespinosa/cookbook-kube/pull/13#issuecomment-248155651

We are upgrading to Kubernetes 1.5 (and 1.6 soon after) and want to add some new options. Rather than add all the new options every time they change I've taken a stab at the proposal suggested earlier of using a single `options` property.

I haven't been able to run the tests for this yet as the Kitchen configuration hasn't worked for me. But hoping to get some early feedback.