### PR TITLE
add --rotate-certificates flag for kubelet

### DIFF
--- a/libraries/kubelet.rb
+++ b/libraries/kubelet.rb
@@ -226,6 +226,7 @@ module KubernetesCookbook
     property :rkt_path
     property :rkt_stage1_image
     property :root_dir, default: '/var/lib/kubelet'
+    property :rotate_certificates
     property :runonce
     property :runtime_cgroups
     property :runtime_request_timeout, default: '2m0s'


### PR DESCRIPTION
We would like to use `--rotate-certificates` in cookbook-kube.

Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/