### PR TITLE
remove default value of kubeconfig

### DIFF
--- a/libraries/command_generator.rb
+++ b/libraries/command_generator.rb
@@ -44,7 +44,7 @@ module KubernetesCookbook
     def list_commandline_flag_properties
       @resource.class.properties.reject do |property, description|
         value = @resource.send(property)
-        non_commandline_property?(property) || (value == description.default)
+        non_commandline_property?(property)
       end
     end
   end

--- a/libraries/command_generator.rb
+++ b/libraries/command_generator.rb
@@ -44,7 +44,7 @@ module KubernetesCookbook
     def list_commandline_flag_properties
       @resource.class.properties.reject do |property, description|
         value = @resource.send(property)
-        non_commandline_property?(property)
+        non_commandline_property?(property) || (value == description.default)
       end
     end
   end

--- a/libraries/kubelet.rb
+++ b/libraries/kubelet.rb
@@ -191,7 +191,7 @@ module KubernetesCookbook
     property :kube_api_qps, default: 5
     property :kube_reserved
     property :kube_reserved_cgroup
-    property :kubeconfig, default: '/var/lib/kubelet/kubeconfig'
+    property :kubeconfig
     property :kubelet_cgroups
     property :lock_file
     property :make_iptables_util_chains, default: true


### PR DESCRIPTION
There may be difference between some default values of k8s and cookbook-kube. For example, `kubeconfig` no longer has default value.
https://github.com/kubernetes/kubernetes/blob/39dd1f8d15d35207dcd0f30b790c403e66f2fe50/cmd/kubelet/app/options/options.go#L376
~~I think this cookbook should not remove options if it is duplicated.~~

Sorry, it should not remove the options so this PR only removes a default value of `kubeconfig`.